### PR TITLE
Add udev rule and update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,18 @@ Based on Qt 5.9.0 (GCC 5.3.1 20160406 (Red Hat 5.3.1-6), 64 bit)
 libusb: https://sourceforge.net/projects/libusb/
 --
 
-USB Access：sudo chmod -R 777 /dev/bus/usb/
+Installation
+--
+
+Arch Linux: Package available through [AUR](https://aur.archlinux.org/packages/drevo-power-console-git/)
+
+To be able to run the program with non root access you will need to copy the `udev` rule to your installation:
+
+```bash
+cp udev/77-drevo-usb-allow-wheel.rules /usr/lib/udev/rules.d/
+```
+
+Screenshots
 --
 
 ![](https://github.com/lanyu7/dpc_linux/blob/master/picture/1.png)

--- a/udev/77-drevo-usb-allow-wheel.rules
+++ b/udev/77-drevo-usb-allow-wheel.rules
@@ -1,0 +1,7 @@
+SUBSYSTEM=="usb", ATTRS{idVendor}=="1a2c", ATTRS{idProduct}=="b31f", MODE="0660", GROUP="wheel"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="1a2c", ATTRS{idProduct}=="b51f", MODE="0660", GROUP="wheel"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="1a2c", ATTRS{idProduct}=="b58f", MODE="0660", GROUP="wheel"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="1a2c", ATTRS{idProduct}=="b5bf", MODE="0660", GROUP="wheel"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="1a2c", ATTRS{idProduct}=="b57e", MODE="0660", GROUP="wheel"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="1a2c", ATTRS{idProduct}=="b58e", MODE="0660", GROUP="wheel"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="1a2c", ATTRS{idProduct}=="b5be", MODE="0660", GROUP="wheel"


### PR DESCRIPTION
It's really not advisable to `chmod 777 -R /dev/bus/usb`.
This helps having the `DrevoPowerConsole` run as non root without sacrificing security.